### PR TITLE
Extended DUML.rb & Upgrade.rb 

### DIFF
--- a/DUML.rb
+++ b/DUML.rb
@@ -248,13 +248,6 @@ class DUML
         crc
     end
 
-    def hexdump(buf)
-        out = ""
-        buf.each_byte do |b|
-            out += "%02x " % b
-        end
-        puts out
-    end
 
 
     def cmd_enter_upgrade_mode() # 0x07
@@ -408,20 +401,6 @@ end
 
 if __FILE__ == $0
     # debugging
-    duml = DUML.new(src: 0x2a, dst: 0x28)
-    duml.hexdump(DUML::Msg.new(attributes: 0x40, set: 0x00, id: 0x00).raw)
-    duml.hexdump(DUML::Msg.new(attributes: 0x40, set: 0x00, id: 0x07, payload: [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]).raw)
-    duml.hexdump(DUML::Msg.new(attributes: 0x40, set: 0x00, id: 0x08, payload: [ 0x00 ] + [ 0x12345678 ].pack("L<").unpack("CCCC") + [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x04 ]).raw)
-    duml.hexdump(duml.cmd_upgrade_data(filesize: 0x12345678, path: 2, type: 4).raw)
-    duml.hexdump(duml.cmd_transfer_upgrade_data(index: 100, data: Array.new(1000, 0)).raw)
-    puts duml.cmd_transfer_upgrade_data(index: 100, data: Array.new(1000, 0))
-    duml.hexdump(duml.cmd_dev_ping(dst: 0x1f).raw)
-    duml.hexdump(duml.cmd_dev_ping().raw)
-    msg = duml.cmd_upgrade_data(filesize: 0x12345678, path: 2, type: 4).raw
-    duml.hexdump(msg)
-    msg2 = DUML::Msg.from_bytes(msg)
-    duml.hexdump(msg2.raw)
-    puts msg2
 end
 
 # vim: expandtab:ts=4:sw=4

--- a/DUML.rb
+++ b/DUML.rb
@@ -248,30 +248,39 @@ class DUML
         crc
     end
 
+    # -------------------------------------------------------------------------------------------------------------
 
 
     def cmd_enter_upgrade_mode() # 0x07
-        Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x07, payload:
-            [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ])
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x07, payload:
+            [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]))
+        # reply payload: 00 03 0f
+        return reply
     end
 
     def cmd_upgrade_data(filesize:, path:, type:) # 0x08
-        Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x08, payload:
-                [ 0x00 ] + [ filesize ].pack("L<").unpack("CCCC") + [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, path, type ])
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x08, payload:
+                [ 0x00 ] + [ filesize ].pack("L<").unpack("CCCC") + [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, path, type ]))
     end
 
     def cmd_transfer_upgrade_data(index:, data:) # 0x09
-        Msg.new(src: @src, dst: @dst, attributes: 0x00, set: 0x00, id: 0x09, payload:
-            [ 0x00 ] + [ index ].pack("L<").unpack("CCCC") + [ data.length ].pack("S<").unpack("CC") + data)
+        send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x00, set: 0x00, id: 0x09, payload:
+            [ 0x00 ] + [ index ].pack("L<").unpack("CCCC") + [ data.length ].pack("S<").unpack("CC") + data))
     end
 
     def cmd_finish_upgrade_data(md5:) # 0x0a
-        Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x0a, payload:
-            [ 0x00 ] + md5)
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x0a, payload:
+            [ 0x00 ] + md5))
+        return reply
     end
 
     def cmd_report_status() # 0x0c
-        Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x0c, payload: [ 0x00 ])
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x0c, payload: [ 0x00 ]))
+        # reply payload: 00 00 01 00 00 00
+        return reply
+    end
+
+    # -------------------------------------------------------------------------------------------------------------
 
     def send(msg:, timeout: @timeout)
         if msg.attributes == 0x40

--- a/DUML.rb
+++ b/DUML.rb
@@ -315,6 +315,25 @@ class DUML
         return reply
     end
 
+    def cmd_common_get_cfg_file(type:) # 0x4f
+        buf = ""
+        remaining = 0xffffffff
+        length = 0xffffffff
+        offset = 0
+        loop do
+            reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x4f, payload:
+                                      [ type, offset, length ].pack("CL<L<").unpack("CCCCCCCCC")))
+
+            remaining = reply.payload[5..8].pack("C*").unpack("L<")[0]
+            length = reply.payload[1..4].pack("C*").unpack("L<")[0]
+            offset += length
+            buf += reply.payload[9..-1].pack("C*")
+            break if remaining == 0
+        end
+
+        return buf
+    end
+
     def cmd_query_device_info() # 0xff
         reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0xff))
         return reply.payload[1..-1].pack("C*")

--- a/DUML.rb
+++ b/DUML.rb
@@ -302,6 +302,11 @@ class DUML
         return reply
     end
 
+    def cmd_stop_push() # 0x41
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x41, payload: [ 0x04 ]))
+        return reply
+    end
+
     # -------------------------------------------------------------------------------------------------------------
 
     def send(msg:, timeout: @timeout)

--- a/DUML.rb
+++ b/DUML.rb
@@ -307,6 +307,11 @@ class DUML
         return reply
     end
 
+    def cmd_query_device_info() # 0xff
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0xff))
+        return reply.payload[1..-1].pack("C*")
+    end
+
     # -------------------------------------------------------------------------------------------------------------
 
     def send(msg:, timeout: @timeout)

--- a/DUML.rb
+++ b/DUML.rb
@@ -250,6 +250,14 @@ class DUML
 
     # -------------------------------------------------------------------------------------------------------------
 
+    def cmd_dev_ver_get() # 0x01
+        reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x01))
+        # 00 12 57 4d 32 32 30 20 52 43 20 56 65 72 2e 41 00 00 17 00 05 01 17 00 05 01 01 00 00 80 00
+        # WM220 RC Ver.A
+        # 00 12 57 4d 32 32 30 20 41 43 20 56 65 72 2e 41 00 00 14 00 05 01 14 00 05 01 01 00 00 80 00
+        # WM220 AC Ver.A
+        return reply.payload[2..16].pack("C*")
+    end
 
     def cmd_enter_upgrade_mode() # 0x07
         reply = send(msg: Msg.new(src: @src, dst: @dst, attributes: 0x40, set: 0x00, id: 0x07, payload:

--- a/RubaDubDUML.rb
+++ b/RubaDubDUML.rb
@@ -53,11 +53,11 @@ class PwnSauce
         # note the 0x143... and usbmodem143...
 
         puts "Connecting to serial: #{port_str}"
-        output = UpgradeOutputSerial.new(port_str)
+        connection = DUML::ConnectionSerial.new(port_str)
 
         puts "To debug, if you have root: busybox tail -f /ftp/upgrade/dji/log/upgrade00.log | grep -v sys_up_status_push_threa"
 
-        upgrade = Upgrade.new(filename: filename, connection: output)
+        upgrade = Upgrade.new(filename: filename, connection: connection)
         upgrade.go
 
         Net::HTTP.start("www.openpilotlegacy.org") do |http| resp = http.get("/RubaDubDUML.txt") end # Old Beta Release Leak Control... you can remove this

--- a/Upgrade.rb
+++ b/Upgrade.rb
@@ -16,7 +16,7 @@ class Upgrade
             raise "#{@filename} doesn't exists"
         end
         @data = File.read(@filename).unpack("C*")
-        @duml = DUML.new(src: src, dst: dst)
+        @duml = DUML.new(src: src, dst: dst, connection: connection)
         @targetfile = targetfile
         @path = path
         @type = type
@@ -75,56 +75,21 @@ class Upgrade
     end
 end
 
-class UpgradeOutput
-    def write(buf)
-        out = ""
-        buf.each_byte do |b|
-            out += "%02x " % b
-        end
-        puts out
-    end
-end
-
-class UpgradeOutputSerial < UpgradeOutput
-    def initialize(port)
-        baud_rate = 115200
-        data_bits = 8
-        stop_bits = 1
-        parity = SerialPort::NONE
-
-        @sp = SerialPort.new(port, baud_rate, data_bits, stop_bits, parity)
-    end
-
-    def write(buf)
-        #super(buf)
-        @sp.write(buf)
-    end
-end
-
-class UpgradeOutputSocket < UpgradeOutput
-    def initialize(hostname, port)
-        @sock = TCPSocket.open(hostname, port)
-    end
-
-    def write(buf)
-        #super(buf)
-        @sock.write(buf)
-    end
-end
-
 if __FILE__ == $0
     # debugging
 
-    out = UpgradeOutput.new
-    #out = UpgradeOutputSocket.new("localhost", 19003)
-    #out = UpgradeOutputSocket.new("192.168.1.1", 19003)
-    #out = UpgradeOutputSerial.new("/dev/tty.usbmodem1415")
+    #con = DUML::Connection.new
+    #con = DUML::ConnectionSocket.new("localhost", 19003)
+    #con = DUML::ConnectionSocket.new("192.168.1.1", 19003)
+    con = DUML::ConnectionSerial.new("/dev/tty.usbmodem1425")
 
-    #aircraft = Upgrade.new(connection: out)
-    #mavic_rc = Upgrade.new(dst: 0x2d, connection: out)
-    #googles =  Upgrade.new(dst: 0x3c, connection: out)
-    spark_rc = Upgrade.new(filename: "fw.tar", src: 0x02, dst: 0x1b, path: 1, ftp: false, connection: out)
-    spark_rc.go
+    #aircraft = Upgrade.new(connection: con)
+    mavic_rc = Upgrade.new(dst: 0x2d, connection: con)
+    mavic_rc.go
+    #googles =  Upgrade.new(dst: 0x3c, connection: con)
+    #spark_rc = Upgrade.new(filename: "fw.tar", src: 0x02, dst: 0x1b, path: 1, ftp: false, connection: con)
+    #spark_rc.go
+    sleep(120)
 end
 
 # vim: expandtab:ts=4:sw=4

--- a/Upgrade.rb
+++ b/Upgrade.rb
@@ -27,6 +27,7 @@ class Upgrade
     def init_upgrade
         @connection.write(@duml.cmd_enter_upgrade_mode())
         @connection.write(@duml.cmd_report_status())
+        @connection.write(@duml.cmd_upgrade_data(filesize: @data.length, path: @path, type: @type))
     end
 
     def ftp_transfer_file
@@ -40,8 +41,6 @@ class Upgrade
             puts "FTP Error"
         end
         ftp.close
-
-        @connection.write(@duml.cmd_upgrade_data(filesize: @data.length, path: @path, type: @type))
     end
 
     def duml_transfer_file

--- a/Upgrade.rb
+++ b/Upgrade.rb
@@ -6,72 +6,113 @@ require 'net/http'
 require 'net/ftp'
 require 'socket'
 require 'digest'
+require 'colorize'
 $:.unshift File.expand_path('.',__dir__)
 require 'DUML.rb'
 
 class Upgrade
-    def initialize(filename: "dji_system.bin", targetfile: "dji_system.bin", src: 0x2a, dst: 0x28, path: 2, type: 4, ftp: true, connection:)
+    def initialize(filename: "dji_system.bin", src: 0x2a, dst: 0x28, path: 2, type: 4, connection:, debug: false)
         @filename = filename
         if not File.file?(@filename)
             raise "#{@filename} doesn't exists"
         end
         @data = File.read(@filename).unpack("C*")
-        @duml = DUML.new(src: src, dst: dst, connection: connection)
-        @targetfile = targetfile
+        @duml = DUML.new(src: src, dst: dst, connection: connection, timeout: 1.0, debug: debug)
         @path = path
         @type = type
-        @ftp = ftp
-        @connection = connection
+        @debug = debug
     end
 
-    def init_upgrade
-        @connection.write(@duml.cmd_enter_upgrade_mode())
-        @connection.write(@duml.cmd_report_status())
-        @connection.write(@duml.cmd_upgrade_data(filesize: @data.length, path: @path, type: @type))
+    def upgrade_status(msg:)
+        case msg.payload[0]
+        when 1
+            print "  Upgrade not yet started\r"
+        when 3
+            print "  Upgrade in progress: %2d %%\r" % msg.payload[1]
+        when 4
+            puts "Upgrade complete, status %02x %02x" % [ msg.payload[1], msg.payload[2] ]
+            #@duml.cmd_stop_push() <-- Can't do this from this context, it locks up the read thread.
+            @done = true
+        end
+        puts if @debug
+        $stdout.flush
     end
 
-    def ftp_transfer_file
-        ftp = Net::FTP.new('192.168.42.2')
+    def go
+        @done = false;
+
+        # Register a callback to get upgrade progress notification
+        @duml.register_handler(set: 0x00, id: 0x42) do |msg| upgrade_status(msg: msg); end
+
+        puts ("Talking to: " + @duml.cmd_query_device_info()).yellow
+        puts ("            " + @duml.cmd_dev_ver_get()).yellow
+
+        # Get the cfg.sig file of the last upgrade to parse out the version string.
+        # It's a full-featured IM*H file, but I got lazy and just regex'ed the version string out of it...
+        reply = @duml.cmd_common_get_cfg_file(type: 1)
+        puts ("            " + reply.scan( /<firmware formal="([^"]*)">/).first.last).yellow
+
+        # Here we go...
+        @duml.cmd_enter_upgrade_mode()
+
+        # Request upgrade progress notifications
+        @duml.cmd_report_status()
+
+        reply = @duml.cmd_upgrade_data(filesize: @data.length, path: @path, type: @type)
+        if reply == nil
+            puts "Error...".red
+            exit
+        elsif reply[:ftp] == true
+            ftp_transfer_file(reply[:address], reply[:port], reply[:targetfile])
+        else
+            duml_transfer_file(reply[:transfer_size])
+        end
+
+        md5 = Digest::MD5.new
+        md5 << File.read(@filename)
+        @duml.cmd_finish_upgrade_data(md5: md5.digest.unpack("C*"))
+
+        # Sleep until the progress callback tells us we're done.
+        # TODO: a timeout would be nice...
+        # TODO: a condition/wait would be also be nicer than a sleep() in a loop...
+        loop do
+            sleep(1)
+            break if @done
+        end
+
+        # We no longer need the upgrade progress notifications
+        @duml.cmd_stop_push()
+
+        # Read out the version after the upgrade.
+        reply = @duml.cmd_common_get_cfg_file(type: 1)
+        puts ("Currently running: " + reply.scan( /<firmware formal="([^"]*)">/).first.last).yellow
+    end
+
+    def ftp_transfer_file(address, port, targetfile)
+        puts "Transfering upgrade data over ftp: %s:%d -> %s" % [ address, port, targetfile ]
+        ftp = Net::FTP.new(address, port)
         ftp.passive = true
         ftp.login("root", "Big~9China")
         begin
             firmware = File.new(@filename)
-            ftp.putbinaryfile(firmware, "/upgrade/" + @targetfile)
+            ftp.putbinaryfile(firmware, targetfile)
         rescue Net::FTPPermError
             puts "FTP Error"
         end
         ftp.close
     end
 
-    def duml_transfer_file
-        @connection.write(@duml.cmd_upgrade_data(filesize: @data.length, path: @path, type: @type))
-        # TODO: The reply to this command has the max block size to use for the transfer
-
+    def duml_transfer_file(max_transfer_size)
+        puts "Transferring upgrade data over duml messages"
         left = @data.length
         index = 0
         while left > 0
-            transfer = [ left, 1000 ].min
-            @connection.write(@duml.cmd_transfer_upgrade_data(index: index, data: @data[index * 1000, transfer]))
+            transfer = [ left, max_transfer_size ].min
+            @duml.cmd_transfer_upgrade_data(index: index, data: @data[index * max_transfer_size, transfer])
 
             index += 1
             left -= transfer
         end
-    end
-
-    def start_upgrade
-        md5 = Digest::MD5.new
-        md5 << File.read(@filename)
-        @connection.write(@duml.cmd_finish_upgrade_data(md5: md5.digest.unpack("C*")))
-    end
-
-    def go
-        init_upgrade
-        if @ftp
-            ftp_transfer_file()
-        else
-            duml_transfer_file()
-        end
-        start_upgrade
     end
 end
 
@@ -83,13 +124,13 @@ if __FILE__ == $0
     #con = DUML::ConnectionSocket.new("192.168.1.1", 19003)
     con = DUML::ConnectionSerial.new("/dev/tty.usbmodem1425")
 
-    #aircraft = Upgrade.new(connection: con)
-    mavic_rc = Upgrade.new(dst: 0x2d, connection: con)
+    #aircraft = Upgrade.new(connection: con, debug: false)
+    #aircraft.go
+    mavic_rc = Upgrade.new(dst: 0x2d, connection: con, debug: false)
     mavic_rc.go
     #googles =  Upgrade.new(dst: 0x3c, connection: con)
-    #spark_rc = Upgrade.new(filename: "fw.tar", src: 0x02, dst: 0x1b, path: 1, ftp: false, connection: con)
+    #spark_rc = Upgrade.new(filename: "fw.tar", src: 0x02, dst: 0x1b, path: 1, connection: con)
     #spark_rc.go
-    sleep(120)
 end
 
 # vim: expandtab:ts=4:sw=4


### PR DESCRIPTION
Quite a long list of changes, the commit messages contain it all.
Here's a summary:

- DUML generated/parsed both ways: when sending a command which expects a reply, 
  the method blocks until a reply to this command has been received (or a timeout happens first)
- Callbacks can be registered for commands sent by the device
- Methods for a bunch of DUML commands (and parsers for their replies), mostly upgrade related.
- Upgrade uses these features to register a callback for receiving upgrade progress status
- When the connection gets lost, it retries to reconnect for 20 seconds (needed because the
  device reboots during upgrade)
- ...